### PR TITLE
[FIX] tg_portal: избегаем ошибки при вводе паспорта/cedula, если у контакта уже 2 или более

### DIFF
--- a/tg_portal/README.rst
+++ b/tg_portal/README.rst
@@ -13,6 +13,12 @@
   *  Country of Citizenship
   *  Date of Birth
 
+* Passport and Cedula
+
+  * Last modified ID are treated as current
+
+  * If partner has 2 or more IDs, new one is created
+
 Credits
 =======
 

--- a/tg_portal/__manifest__.py
+++ b/tg_portal/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": """Portal modifications for Tribal Gathering""",
-    "version": "17.0.0.1.0",
+    "version": "17.0.0.1.1",
     "author": "IT-Projects LLC, Eugene Molotov",
     "support": "it@it-projects.info",
     "website": "https://github.com/it-projects-llc/tg-addons",
@@ -13,6 +13,7 @@
     ],
     "data": [
         "views/portal_templates.xml",
+        "views/res_partner_views.xml",
     ],
     "demo": [],
     "assets": {

--- a/tg_portal/models/res_partner.py
+++ b/tg_portal/models/res_partner.py
@@ -12,7 +12,7 @@ class Partner(models.Model):
             "passport",
             "passport",
         ),
-        inverse=lambda s: s._inverse_identification(
+        inverse=lambda s: s._inverse_identification2(
             "passport",
             "passport",
         ),
@@ -25,7 +25,7 @@ class Partner(models.Model):
             "cedula",
             "cedula",
         ),
-        inverse=lambda s: s._inverse_identification(
+        inverse=lambda s: s._inverse_identification2(
             "cedula",
             "cedula",
         ),
@@ -46,3 +46,39 @@ class Partner(models.Model):
         for partner in self:
             if not partner.has_cedula:
                 partner.cedula = ""
+
+    # based on _inverse_identification from partner_identification
+    # ValidationError was removed for multiple IDs case
+    def _inverse_identification2(self, field_name, category_code):
+        for record in self:
+            id_number = record.id_numbers.filtered(
+                lambda r: r.category_id.code == category_code
+            )
+            record_len = len(id_number)
+
+            if record_len == 1:
+                value = record[field_name]
+                if value:
+                    id_number.name = value
+                else:
+                    id_number.active = False
+            else:
+                name = record[field_name]
+                if not name:
+                    # No value to set
+                    continue
+                category = self.env["res.partner.id_category"].search(
+                    [("code", "=", category_code)]
+                )
+                if not category:
+                    category = self.env["res.partner.id_category"].create(
+                        {"code": category_code, "name": category_code}
+                    )
+                self.env["res.partner.id_number"].create(
+                    {"partner_id": record.id, "category_id": category.id, "name": name}
+                )
+
+
+class PartnerIdNumber(models.Model):
+    _inherit = "res.partner.id_number"
+    _order = "write_date DESC, id DESC"

--- a/tg_portal/tests/__init__.py
+++ b/tg_portal/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ident

--- a/tg_portal/tests/test_ident.py
+++ b/tg_portal/tests/test_ident.py
@@ -1,0 +1,52 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestPartnerIdentificationBase(TransactionCase):
+    def _test_multiple_idents(self, ident_code):
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Partner with multiple idents",
+            }
+        )
+
+        partner[ident_code] = "123"  # this creates ident category record
+        ident_category = self.env["res.partner.id_category"].search(
+            [
+                ("code", "=", ident_code),
+            ]
+        )
+        self.assertTrue(bool(ident_category))
+
+        partner.write(
+            {
+                "name": "Partner with multiple idents",
+                "id_numbers": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "456",
+                            "category_id": ident_category.id,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(len(partner.id_numbers), 2)
+
+        new_ident_code = "345"
+        partner[ident_code] = new_ident_code
+        self.assertEqual(len(partner.id_numbers), 3)
+
+        # this also ensures, that last updated one is used as current
+        first_by_name = sorted(partner.mapped("id_numbers.name"))[0]
+        self.assertNotEqual(first_by_name, new_ident_code, "Incorrect test case")
+
+        partner.invalidate_recordset()
+        self.assertEqual(partner[ident_code], new_ident_code)
+
+    def test_multiple_passport(self):
+        self._test_multiple_idents("passport")
+
+    def test_multiple_cedula(self):
+        self._test_multiple_idents("cedula")

--- a/tg_portal/views/res_partner_views.xml
+++ b/tg_portal/views/res_partner_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.passport.cedula</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="partner_identification.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='id_numbers']" position="before">
+                <group groups="base.group_no_one">
+                    <field name="passport" />
+                    <field name="cedula" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
В качестве основного будет использоваться тот, который последний записан