### PR TITLE
[FIX] website_sale_renting: исправление энтерпрайз модуля через tg_website_sale

### DIFF
--- a/tg_website_sale/README.rst
+++ b/tg_website_sale/README.rst
@@ -8,6 +8,10 @@
 
   * Hides "email" field for registered user
 
+* For rental products (enterprise):
+
+  * fixes product configurator modal showing incorrect period, that user did not choose
+
 Credits
 =======
 

--- a/tg_website_sale/__init__.py
+++ b/tg_website_sale/__init__.py
@@ -1,2 +1,12 @@
 from . import models
 from . import controllers
+
+import importlib
+
+if (
+    importlib.util.find_spec("odoo.addons.website_sale_renting_product_configurator")
+    is not None
+):
+    # importing enterprise module
+    # without adding it as dependency
+    from . import website_sale_renting_fix

--- a/tg_website_sale/website_sale_renting_fix.py
+++ b/tg_website_sale/website_sale_renting_fix.py
@@ -1,0 +1,32 @@
+from odoo.http import request, route
+
+from odoo.addons.website_sale_renting.controllers.variant import (
+    WebsiteSaleRentingVariantController,
+)
+from odoo.addons.website_sale_renting_product_configurator.controllers.configurator import (  # noqa: E501
+    RentingConfiguratorController,
+)
+
+
+class FixedRentingConfigurator(RentingConfiguratorController):
+    @route()
+    def show_advanced_configurator(self, *args, **kw):
+        if (kw.get("context") or {}).get("start_date"):
+            request.update_context(start_date=kw["context"]["start_date"])
+
+        if (kw.get("context") or {}).get("end_date"):
+            request.update_context(end_date=kw["context"]["end_date"])
+
+        return super().show_advanced_configurator(*args, **kw)
+
+
+class FixedWebsiteSaleRentingVariantController(WebsiteSaleRentingVariantController):
+    @route()
+    def get_combination_info_website(self, *args, **kw):
+        if (kw.get("context") or {}).get("start_date"):
+            kw["start_date"] = kw["context"]["start_date"]
+
+        if (kw.get("context") or {}).get("end_date"):
+            kw["end_date"] = kw["context"]["end_date"]
+
+        return super().get_combination_info_website(*args, **kw)


### PR DESCRIPTION
Пользователю при запуске конфигуратора выводился неправильный подсчет количества выбранных дней